### PR TITLE
Added ConfigMap example for OIDC

### DIFF
--- a/templates/configMap.yaml
+++ b/templates/configMap.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.owncloud.oidc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: owncloud-config
+  namespace: default
+data:
+  docker.oidc.config.php: |
+    <?php
+    $CONFIG = [
+            "openid-connect" => [
+                    "provider-url" => $_ENV["OWNCLOUD_OIDC_PROVIDER_URL"],
+                    "post_logout_redirect_uri" => $_ENV["OWNCLOUD_OIDC_POST_LOGOUT_REDIRECT_URL"],
+                    "client-id" => $_ENV["OWNCLOUD_OIDC_CLIENT_ID"],
+                    "client-secret" => $_ENV["OWNCLOUD_OIDC_CLIENT_SECRET"],
+                    "loginButtonName" => "Azure AD",
+                    "autoRedirectOnLoginPage" => false,
+                    "scopes" => [
+                            "openid",
+                            $_ENV["OWNCLOUD_OIDC_SCOPES_API"],
+                            "profile", "email", "offline_access",
+                    ],
+                    "mode" => "email",
+                    "search-attribute" => "unique_name",
+                    "use-access-token-payload-for-user-info" => true,
+                    'auto-provision' => [
+                            'enabled' => true,
+                            'email-claim' => 'email',
+                            'display-name-claim' => 'name',
+                    ],
+            ],
+    ];
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
         - name: "init-{{ .Chart.Name }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume_apps }} {{ .Values.owncloud.volume_config }} {{ .Values.owncloud.volume_files }}; chown -R www-data:www-data {{ .Values.owncloud.volume_root }}"]
+          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume_apps }} {{ .Values.owncloud.volume_config }} {{ .Values.owncloud.volume_files }} {{ .Values.owncloud.volume_root }}/sessions; chown -R www-data:www-data {{ .Values.owncloud.volume_root }}"]
           volumeMounts:
           - name: owncloud-data
             mountPath: {{ .Values.owncloud.volume_root }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -27,6 +27,14 @@ spec:
       serviceAccountName: {{ include "owncloud.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: "init-{{ .Chart.Name }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume_apps }} {{ .Values.owncloud.volume_config }} {{ .Values.owncloud.volume_files }}; chown -R www-data:www-data {{ .Values.owncloud.volume_root }}"]
+          volumeMounts:
+          - name: owncloud-data
+            mountPath: {{ .Values.owncloud.volume_root }}
+
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -36,6 +44,18 @@ spec:
           env:
           - name: OWNCLOUD_DOMAIN
             value: {{ .Values.owncloudDomain | quote }}
+          - name: OWNCLOUD_SKIP_CHMOD
+            value: "true"
+          - name: OWNCLOUD_SKIP_CHOWN
+            value: "true"
+          - name: OWNCLOUD_VOLUME_APPS
+            value: {{ .Values.owncloud.volume_apps | quote }}
+          - name: OWNCLOUD_VOLUME_CONFIG
+            value: {{ .Values.owncloud.volume_config | quote }}
+          - name: OWNCLOUD_VOLUME_FILES
+            value: {{ .Values.owncloud.volume_files | quote }}
+          - name: OWNCLOUD_VOLUME_ROOT
+            value: {{ .Values.owncloud.volume_root | quote }}
           - name: OWNCLOUD_ADMIN_USERNAME
             value: {{ .Values.owncloud.username | quote }}
           - name: OWNCLOUD_ADMIN_PASSWORD
@@ -77,6 +97,18 @@ spec:
           - name: OWNCLOUD_REDIS_HOST
             value: {{ .Values.redis.host | quote }}
           {{- end }}
+          {{- if .Values.owncloud.oidc.enabled }}
+          - name: OWNCLOUD_OIDC_PROVIDER_URL
+            value: {{ .Values.owncloud.oidc.providerurl | quote }}
+          - name: OWNCLOUD_OIDC_POST_LOGOUT_REDIRECT_URL
+            value: {{ .Values.owncloud.oidc.logouturl | quote }}
+          - name: OWNCLOUD_OIDC_CLIENT_ID
+            value: {{ .Values.owncloud.oidc.clientid | quote }}
+          - name: OWNCLOUD_OIDC_CLIENT_SECRET
+            value: {{ .Values.owncloud.oidc.clientsecret | quote }}
+          - name: OWNCLOUD_OIDC_SCOPES_API
+            value: {{ .Values.owncloud.oidc.scopesapi | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -105,7 +137,12 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           - name: owncloud-data
-            mountPath: /mnt/data
+            mountPath: {{ .Values.owncloud.volume_root }}
+          {{- if .Values.owncloud.oidc.enabled }}
+          - name: config-volume
+            mountPath: {{ .Values.owncloud.volume_config }}/docker.oidc.config.php
+            subPath: docker.oidc.config.php
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -122,3 +159,8 @@ spec:
         - name: owncloud-data
           persistentVolumeClaim:
             claimName: {{ include "owncloud.fullname" . }}
+        {{- if .Values.owncloud.oidc.enabled }}
+        - name: config-volume
+          configMap:
+            name: owncloud-config
+        {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "owncloud.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -33,9 +33,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,17 @@ owncloud:
   domain: owncloud.chart.example
   username: owncloud
   password: owncloud
+  volume_apps: /mnt/data/apps
+  volume_config: /mnt/data/config
+  volume_files: /mnt/data/files
+  volume_root: /mnt/data
+  oidc:
+    enabled: true
+    providerurl: test
+    logouturl: test
+    clientid: test
+    clientsecret: test
+    scopesapi: test
 
 mariadb:
   enabled: false
@@ -34,7 +45,7 @@ image:
   repository: docker.io/owncloud/server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 10.6
+  tag: "10.10"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR adds a configMap example for OIDC so that OIDC can be configured within helm. Furthermore it corrects the ingress configuration to make chart work.